### PR TITLE
Add unix time matcher

### DIFF
--- a/lib/machete.ex
+++ b/lib/machete.ex
@@ -94,6 +94,7 @@ defmodule Machete do
   * [`term()`](`Machete.TermMatcher.term/1`) matches any term (including nil)
   * [`time()`](`Machete.TimeMatcher.time/1`) matches `Time` instances
   * [`truthy()`](`Machete.TruthyMatcher.truthy/1`) matches truthy values
+  * [`unix_time()`](`Machete.UnixTimeMatcher.unix_time/1`) matches integers that represent unix time
 
   ## Collection matchers
 
@@ -188,6 +189,7 @@ defmodule Machete do
       import Machete.TermMatcher
       import Machete.TimeMatcher
       import Machete.TruthyMatcher
+      import Machete.UnixTimeMatcher
     end
   end
 end

--- a/lib/machete/matchers/unix_time_matcher.ex
+++ b/lib/machete/matchers/unix_time_matcher.ex
@@ -75,7 +75,9 @@ defmodule Machete.UnixTimeMatcher do
     end
 
     defp matches_type(b) when is_integer(b), do: nil
-    defp matches_type(b), do: mismatch("#{inspect(b)} is not an integer that represents a unix time")
+
+    defp matches_type(b),
+      do: mismatch("#{inspect(b)} is not an integer that represents a unix time")
 
     defp matches_exactly(_, nil), do: nil
 

--- a/lib/machete/matchers/unix_time_matcher.ex
+++ b/lib/machete/matchers/unix_time_matcher.ex
@@ -23,7 +23,7 @@ defmodule Machete.UnixTimeMatcher do
         ]
 
   @doc """
-  Matches against integers that represent Unix time values
+  Matches against integers that represent Unix time values in milliseconds
 
   Takes the following arguments:
 

--- a/lib/machete/matchers/unix_time_matcher.ex
+++ b/lib/machete/matchers/unix_time_matcher.ex
@@ -1,0 +1,119 @@
+defmodule Machete.UnixTimeMatcher do
+  @moduledoc """
+  Defines a matcher that matches integers that represent Unix time in milliseconds
+  """
+
+  import Machete.Mismatch
+
+  defstruct exactly: nil, roughly: nil, before: nil, after: nil
+
+  @typedoc """
+  Describes an instance of this matcher
+  """
+  @opaque t :: %__MODULE__{}
+
+  @typedoc """
+  Describes the arguments that can be passed to this matcher
+  """
+  @type opts :: [
+          {:exactly, Time.t()},
+          {:roughly, Time.t() | :now},
+          {:before, Time.t() | :now},
+          {:after, Time.t() | :now}
+        ]
+
+  @doc """
+  Matches against integers that represent Unix time values
+
+  Takes the following arguments:
+
+  * `exactly`: Requires the matched Unix time to be exactly equal to the specified Unix time
+  * `roughly`: Requires the matched Unix time to be within +/- 10 seconds of the specified Unix time. The
+    atom `:now` can be used to use the current time as the specified Unix time
+  * `before`: Requires the matched Unix time to be before or equal to the specified Unix time. The atom
+    `:now` can be used to use the current time as the specified Unix time
+  * `after`: Requires the matched Unix time to be after or equal to the specified Unix time. The atom `:now`
+    can be used to use the current time as the specified Unix time
+
+  Examples:
+
+      iex> assert :os.system_time(:millisecond) ~> unix_time()
+      true
+
+      iex> assert 1681060000000 ~> unix_time(exactly: 1681060000000)
+      true
+
+      iex> assert :os.system_time(:millisecond) ~> unix_time(roughly: :now)
+      true
+
+      iex> assert 1681060000000 ~> unix_time(roughly: 1681060005000)
+      true
+
+      iex> assert 1681060000000 ~> unix_time(before: :now)
+      true
+
+      iex> assert 1681060000000 ~> unix_time(before: 1681090000000)
+      true
+
+      iex> assert 9991090000000 ~> unix_time(after: :now)
+      true
+
+      iex> assert 1681060000000 ~> unix_time(after: 0)
+      true
+  """
+  @spec unix_time(opts()) :: t()
+  def unix_time(opts \\ []), do: struct!(__MODULE__, opts)
+
+  defimpl Machete.Matchable do
+    def mismatches(%@for{} = a, b) do
+      with nil <- matches_type(b),
+           nil <- matches_exactly(b, a.exactly),
+           nil <- matches_roughly(b, a.roughly),
+           nil <- matches_before(b, a.before),
+           nil <- matches_after(b, a.after) do
+      end
+    end
+
+    defp matches_type(b) when is_integer(b), do: nil
+    defp matches_type(b), do: mismatch("#{inspect(b)} is not an integer that represents a unix time")
+
+    defp matches_exactly(_, nil), do: nil
+
+    defp matches_exactly(b, exactly) do
+      if b != exactly do
+        mismatch("#{inspect(b)} is not equal to #{inspect(exactly)}")
+      end
+    end
+
+    defp matches_roughly(_, nil), do: nil
+    defp matches_roughly(b, :now), do: matches_roughly(b, now())
+
+    defp matches_roughly(b, roughly) when is_integer(roughly) do
+      if (b - roughly) not in -:timer.seconds(10)..:timer.seconds(10) do
+        mismatch("#{inspect(b)} is not within 10 seconds of #{inspect(roughly)}")
+      end
+    end
+
+    defp matches_before(_, nil), do: nil
+    defp matches_before(b, :now), do: matches_before(b, now())
+
+    defp matches_before(b, before) when is_integer(before) do
+      if !(b < before) do
+        mismatch("#{inspect(b)} is not before #{inspect(before)}")
+      end
+    end
+
+    defp matches_after(_, nil), do: nil
+    defp matches_after(b, :now), do: matches_after(b, now())
+
+    defp matches_after(b, after_var) do
+      if !(b > after_var) do
+        mismatch("#{inspect(b)} is not after #{inspect(after_var)}")
+      end
+    end
+
+    defp now do
+      :os.system_time(:millisecond)
+    end
+  end
+end

--- a/lib/machete/matchers/unix_time_matcher.ex
+++ b/lib/machete/matchers/unix_time_matcher.ex
@@ -16,10 +16,10 @@ defmodule Machete.UnixTimeMatcher do
   Describes the arguments that can be passed to this matcher
   """
   @type opts :: [
-          {:exactly, Time.t()},
-          {:roughly, Time.t() | :now},
-          {:before, Time.t() | :now},
-          {:after, Time.t() | :now}
+          {:exactly, integer()},
+          {:roughly, integer() | :now},
+          {:before, integer() | :now},
+          {:after, integer() | :now}
         ]
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,8 @@ defmodule Machete.MixProject do
           Machete.SupersetMatcher,
           Machete.TermMatcher,
           Machete.TimeMatcher,
-          Machete.TruthyMatcher
+          Machete.TruthyMatcher,
+          Machete.UnixTimeMatcher
         ]
       ]
     ]

--- a/test/machete/matchers/unix_time_matcher_test.exs
+++ b/test/machete/matchers/unix_time_matcher_test.exs
@@ -1,0 +1,43 @@
+defmodule Machete.UnixTimeMatcherTest do
+  use ExUnit.Case
+
+  use Machete
+
+  import Machete.Mismatch
+
+  doctest Machete.UnixTimeMatcher
+
+  setup do
+    {:ok, time: :os.system_time(:millisecond)}
+  end
+
+  test "produces a useful mismatch for non unix time" do
+    assert ~T[00:00:00]
+           ~>> unix_time()
+           ~> mismatch("~T[00:00:00] is not an integer that represents a unix time")
+  end
+
+  test "produces a useful mismatch for exactly mismatches" do
+    assert 1681059951018
+           ~>> unix_time(exactly: 1681059951019)
+           ~> mismatch("1681059951018 is not equal to 1681059951019")
+  end
+
+  test "produces a useful mismatch for roughly mismatches" do
+    assert 1681059951018
+           ~>> unix_time(roughly: 1681060006343)
+           ~> mismatch("1681059951018 is not within 10 seconds of 1681060006343")
+  end
+
+  test "produces a useful mismatch for before mismatches" do
+    assert 1681059951018
+           ~>> unix_time(before: 1681059951000)
+           ~> mismatch("1681059951018 is not before 1681059951000")
+  end
+
+  test "produces a useful mismatch for after mismatches" do
+    assert 1681059951018
+           ~>> unix_time(after: 1681059951999)
+           ~> mismatch("1681059951018 is not after 1681059951999")
+  end
+end

--- a/test/machete/matchers/unix_time_matcher_test.exs
+++ b/test/machete/matchers/unix_time_matcher_test.exs
@@ -18,26 +18,26 @@ defmodule Machete.UnixTimeMatcherTest do
   end
 
   test "produces a useful mismatch for exactly mismatches" do
-    assert 1681059951018
-           ~>> unix_time(exactly: 1681059951019)
+    assert 1_681_059_951_018
+           ~>> unix_time(exactly: 1_681_059_951_019)
            ~> mismatch("1681059951018 is not equal to 1681059951019")
   end
 
   test "produces a useful mismatch for roughly mismatches" do
-    assert 1681059951018
-           ~>> unix_time(roughly: 1681060006343)
+    assert 1_681_059_951_018
+           ~>> unix_time(roughly: 1_681_060_006_343)
            ~> mismatch("1681059951018 is not within 10 seconds of 1681060006343")
   end
 
   test "produces a useful mismatch for before mismatches" do
-    assert 1681059951018
-           ~>> unix_time(before: 1681059951000)
+    assert 1_681_059_951_018
+           ~>> unix_time(before: 1_681_059_951_000)
            ~> mismatch("1681059951018 is not before 1681059951000")
   end
 
   test "produces a useful mismatch for after mismatches" do
-    assert 1681059951018
-           ~>> unix_time(after: 1681059951999)
+    assert 1_681_059_951_018
+           ~>> unix_time(after: 1_681_059_951_999)
            ~> mismatch("1681059951018 is not after 1681059951999")
   end
 end


### PR DESCRIPTION
Where unix time is an integer that represents a unix timestamp

For now it only supports milliseconds but in the future it would be nice to support seconds and microseconds as well

Example usage:
```elixir
test "store_uniq uses the current time", %{table: table} do
  DataTracer.store_uniq("uniq", table: table)

  key = nil
  assert DataTracer.all(table: table) ~> [{unix_time(roughly: :now), key, "uniq"}]
end
```