### PR TITLE
Fix non-existing atom exception when accidentally matching on map literal

### DIFF
--- a/test/machete/matchers/literal_map_matcher_test.exs
+++ b/test/machete/matchers/literal_map_matcher_test.exs
@@ -33,6 +33,19 @@ defmodule LiteralMapMatcherTest do
     assert 1 ~>> %{} ~> mismatch("Value is not a map")
   end
 
+  test "produces useful mismatches on non-existing atoms" do
+    assert %{"abcdefghijkl" => 1, "mnopqrstuvwxyz" => 2}
+           ~>> %{"abcdefghijkl" => 1}
+           ~> mismatch("Unexpected key", "mnopqrstuvwxyz")
+
+    assert %{"abcdefghijkl" => 1, "mnopqrstuvwxyz" => 2, "zyxwvutsrq" => 3}
+           ~>> %{"abcdefghijkl" => 1}
+           ~> [
+             %Machete.Mismatch{message: "Unexpected key", path: ["mnopqrstuvwxyz"]},
+             %Machete.Mismatch{message: "Unexpected key", path: ["zyxwvutsrq"]}
+           ]
+  end
+
   describe "nested matchers" do
     test "matches when nested matcher returns empty list" do
       assert %{a: 1} ~>> %{a: test_matcher(behaviour: :match_returning_list)} ~> []

--- a/test/machete/matchers/superset_matcher_test.exs
+++ b/test/machete/matchers/superset_matcher_test.exs
@@ -17,4 +17,8 @@ defmodule SupersetMatcherTest do
   test "produces a useful mismatch for when value is not a map" do
     assert 1 ~>> superset(%{a: 1}) ~> mismatch("1 is not a map")
   end
+
+  test "handles non-existing atoms" do
+    assert %{"abcdefghijkl" => 1, "mnopqrstuvwxyz" => 2} ~> superset(%{"abcdefghijkl" => 1})
+  end
 end


### PR DESCRIPTION
Hi Mat! Thanks so much for this wonderful library. I'm on workplace number 3 where it's been introduced to the delight of my coworkers. ☺️

This PR fixes a crash that looks like this:

```
     ** (ArgumentError) errors were found at the given arguments:

       * 1st argument: not an already existing atom
```

...which was previously occurring when you used the literal map matcher on a map with arbitrary string keys that don't have a corresponding atom defined. For me, this occurred when I forgot to wrap my map matcher in a `superset/1`. So, for instance, what I *meant* was:

```elixir
assert %{"foo" => "bar", "baz" => "bop"} ~> superset(%{"foo" => "bar"})
```

...but what I accidentally wrote was just:

```elixir
assert %{"foo" => "bar", "baz" => "bop"} ~> %{"foo" => "bar"}
```

Because the error was so generic, this was pretty difficult to debug. With this change applied, though, you now get a nice "Unexpected key" error.