### PR TITLE
Pinpoint where mismatches occurred in `in_any_order`

### DIFF
--- a/test/machete/matchers/in_any_order_test.exs
+++ b/test/machete/matchers/in_any_order_test.exs
@@ -9,6 +9,65 @@ defmodule InAnyOrderMatcherTest do
   test "produces a useful mismatch for no matches" do
     assert [1, 2]
            ~>> in_any_order([1, 3])
-           ~> mismatch("[1, 2] does not match any ordering of the specified matchers")
+           ~> mismatch(
+             "[1, 2] does not match any ordering of the specified matchers:\n\n    .1\n      1) 2 is not equal to 3\n"
+           )
+  end
+
+  defmodule BigStruct do
+    defstruct a: 1,
+              b: 2,
+              c: 3,
+              d: 4,
+              e: 5,
+              f: 6,
+              g: 7,
+              h: 8,
+              i: 9,
+              j: 10,
+              k: 11,
+              l: 12,
+              m: 13,
+              n: 14,
+              o: 15,
+              p: 16,
+              q: 17,
+              r: 18,
+              s: 19,
+              t: 20,
+              u: 21,
+              v: 22,
+              w: 23,
+              x: 24,
+              y: 25,
+              z: 26
+  end
+
+  test "drills into structs with mismatches" do
+    assert [~U[2024-01-01 01:02:03Z], ~U[2024-01-01 04:05:07Z]]
+           ~>> in_any_order([
+             struct_like(DateTime, %{
+               hour: 1,
+               minute: 2,
+               second: 3
+             }),
+             struct_like(DateTime, %{
+               hour: 4,
+               minute: 5,
+               second: 6
+             })
+           ])
+           ~> mismatch(
+             "[~U[2024-01-01 01:02:03Z], ~U[2024-01-01 04:05:07Z]] does not match any ordering of the specified matchers:\n\n    .1\n      1) .second: 7 is not equal to 6\n"
+           )
+
+    big_struct1 = %BigStruct{a: 14, b: 32}
+    big_struct2 = %BigStruct{c: 4, d: 9}
+
+    assert [big_struct1, big_struct2]
+           ~>> in_any_order([%BigStruct{}, %BigStruct{a: 14}])
+           ~> mismatch(
+             "[%InAnyOrderMatcherTest.BigStruct{a: 14, b: 32, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10, k: 11, l: 12, m: 13, n: 14, o: 15, p: 16, q: 17, r: 18, s: 19, t: 20, u: 21, v: 22, w: 23, x: 24, y: 25, z: 26}, %InAnyOrderMatcherTest.BigStruct{a: 1, b: 2, c: 4, d: 9, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10, k: 11, l: 12, m: 13, n: 14, o: 15, p: 16, q: 17, r: 18, s: 19, t: 20, u: 21, v: 22, w: 23, x: 24, y: 25, z: 26}] does not match any ordering of the specified matchers:\n    .0\n      1) .b: 32 is not equal to 2\n\n    .1\n      1) .c: 4 is not equal to 3\n      2) .d: 9 is not equal to 4\n"
+           )
   end
 end


### PR DESCRIPTION
This improves the usability of the `in_any_order` matcher when using it on non-primitive values or large lists.

The problem my team encountered was that we would get a mismatch in, say, one field of a very large struct, within a list of a half dozen of those large structs. The previous error message here amounted to "here's the data you gave us, and it didn't match." What we wanted was "here are the fields of the mismatched struct that failed to match."

## Example 1: Primitives

For small lists of primitive, the improvement is minimal.

Before when given the list `[1, 2]` and trying to match against `[1, 3]`:

| Before | After |
|--------|------|
| <img width="555" alt="image" src="https://github.com/user-attachments/assets/1dfafb64-ad5a-41e1-b471-8dcfee2c67ff" />  | <img width="554" alt="image" src="https://github.com/user-attachments/assets/9ed5e31a-9eef-4dad-a4d3-61e67d4cd092" /> | 

## Example 2: DateTimes

The changes here are a bigger deal when working with DateTimes. Consider this case for the code

```elixir
    assert [~U[2024-01-01 01:02:03Z], ~U[2024-01-01 04:05:07Z]]
           ~> in_any_order([
             struct_like(DateTime, %{
               hour: 1,
               minute: 2,
               second: 3
             }),
             struct_like(DateTime, %{
               hour: 4,
               minute: 5,
               second: 6
             })
           ])
```


| Before | After |
|--------|------|
|   <img width="841" alt="image" src="https://github.com/user-attachments/assets/2abcf6b0-5e2a-4084-80ab-b78675641649" />  |   <img width="841" alt="image" src="https://github.com/user-attachments/assets/ebdf7d14-29a8-42dc-b09c-c591e789fd51" />    | 


Before, it's quite hard to tell which field didn't match, but after, it's easier to pinpoint where we received a 7 but expected a 6.

## Example 3: A really big struct

| Before | After |
|--------|------|
|   <img width="1094" alt="image" src="https://github.com/user-attachments/assets/541a8185-3db2-48dd-a33f-6a7dc3857fb3" />  |    <img width="1091" alt="image" src="https://github.com/user-attachments/assets/320df96b-3192-4701-afb1-0f1934ca7d6b" />   |
